### PR TITLE
Feature/unguessable urls import structure

### DIFF
--- a/lib/persistence/redis/Base.js
+++ b/lib/persistence/redis/Base.js
@@ -2,14 +2,20 @@ var Q = require("q");
 var redis_client = require('./client.js');
 var uuid = require('node-uuid');
 
-module.exports = function(model){
+module.exports = function(options){
+
+  var name = options['name'];
+  if ( !name ) { throw new Error("name is required"); }
+
+  var model = options['model'];
+  if ( !model ) { throw new Error("model is required"); }
 
   var redis_model = require('../backbone_sync.js')(model)
 
   redis_model = redis_model.extend({
 
     pk: function(){
-      throw new Error("You must define a pk method!")
+      return name + ':' + this.id;
     },
 
     create: function(options){

--- a/lib/persistence/redis/Board.js
+++ b/lib/persistence/redis/Board.js
@@ -1,13 +1,9 @@
 var Q = require("q");
 
 module.exports = function(weiqi){
-  var BaseBoard = require('./Base')(weiqi.Board)
+  var BaseBoard = require('./Base')({model: weiqi.Board, name: 'board'})
   
   weiqi.Board = BaseBoard.extend({
-
-    pk: function(){
-      return 'board' + ':' + this.id;
-    },
 
     create: function() {
       var board = this;

--- a/lib/persistence/redis/Player.js
+++ b/lib/persistence/redis/Player.js
@@ -3,13 +3,9 @@ var Q = require("q");
 
 module.exports = function(weiqi){
 
-var BasePlayer = require('./Base')(Backbone.Model);
+var BasePlayer = require('./Base')({model: Backbone.Model, name: 'player'});
 
 weiqi.Player = BasePlayer.extend({
-
-  pk: function(){
-    return 'player' + ':' + this.id;
-  },
 
   create: function() {
     var player = this;


### PR DESCRIPTION
Mike, I added a commit here that brings back the old import structure because I think that we should be consistent in our approach to the namespacing issue, start a conversation about it.

The advantage here is a pattern that provides a private/public namespace and provides a single way to define the weiqi models. If we flatten access to the models (that is `require` bits and pieces anywhere), it seem to me that there could be some complexity issues.  Re: require patterns, I think this style of cobbling together a namespace is like the way a library is defined, rather then how an end user ultimately `requires` that library.  

Generally, how can we guarantee that a model behaves the same in all contexts? There is plenty wrong with the current approach, but I feel that we need a general solution here.
[edited]
