### PR TITLE
more debugging output

### DIFF
--- a/controllers/boards.js
+++ b/controllers/boards.js
@@ -28,7 +28,9 @@ module.exports = function(app){
     player.fetch().then(function() {
       board_id = player.get('board_id');
       board = new weiqi.Board({ id: board_id });
-      return board.fetch();
+      return board.fetch().then(function(json){
+        console.log('these widths should match', board.get('width'), json.width)
+      });
     }).then(function() {
       console.log("board width in controller is " + board.get('width'));
       if(req.params.format == 'json') {


### PR DESCRIPTION
This pull request is to elucidate the bug.

This added debug line shows that the attributes are being persisted correctly. 

My initial sense of the bug is that it is related to the way the "defaults" are applied to the Backbone model. If you comment out [this line](https://github.com/michaelkirk/weiqi/blob/feature/small_board/public/js/models/Board.js#L5), the bug goes away, that is the {width:9} attribute is passed down all the way to the client correctly.

Why this is? I'm not sure. Here is another way to visualize the bug:

```
    weiqi> var board1 = new weiqi.Board({width:9});
    undefined
    weiqi> board1.save()
    { promiseSend: [Function],
      valueOf: [Function] }
    weiqi> width attribute was: 9
    width attribute was: 9

    undefined
    weiqi> board1.get('width')
    9
    weiqi> var board2 = new weiqi.Board({id: board1.id})
    undefined
    weiqi> board2.fetch()
    { promiseSend: [Function],
      valueOf: [Function] }
    weiqi> width attribute was: 9
    weiqi> board2.get('width')
    19
    weiqi> board1.fetch()
    { promiseSend: [Function],
      valueOf: [Function] }
    weiqi> width attribute was: 9
    weiqi> board1.get('width')
    9
    weiqi>
```

So in the end it appears that the default of 19 is overwriting the 9 that is in the datastore. 
