### PR TITLE
keep the cell_views indexed by position, remove reverse view relation

### DIFF
--- a/public/js/views/BoardView.js
+++ b/public/js/views/BoardView.js
@@ -9,12 +9,11 @@
     initialize: function(options) {
       options = options || {}
       this.player_color = options['player_color'];
-      this.cell_views = [];
+      this.cell_views = {};
       var board_view = this;
-      _.each(this.model.cells, function(rows) {
-        _.each(rows, function(cell) {
-          board_view.cell_views.push(new weiqi.CellView({model: cell, board_view: board_view}));
-        });
+      _.each(_.flatten(this.model.cells), function(cell) {
+        new_cell_view = new weiqi.CellView({model: cell, board_view: board_view});
+        board_view.cell_views[board_view._cell_view_key(cell.get('x'), cell.get('y'))] = new_cell_view
       });
       this.template = _.template('\
         <div class="board board<%= width %>"> \
@@ -40,18 +39,35 @@
 
       this.render();
     },
+    _cell_view_key: function(x, y) { return x + '-' + y}, 
+    get_cell_view: function(x, y) {
+      if(x < this.model.get('width') && y < this.model.get('width')){
+        return this.cell_views[this._cell_view_key(x, y)];
+      }
+      else {
+        throw new Error("attempting to accessing outside of game board");
+      }
+    },
     update_turn: function() {
       if(this.model.whose_turn() == this.player_color) {
         this.$el.addClass("your-turn");
       } else {
         this.$el.removeClass("your-turn");
       }
+      this.indicate_latest_move();
+
+    },
+    indicate_latest_move: function(){
+
+      var latest_move = this.model.moves.last();
 
       $('.jgo_m', this.$el).removeClass('circle_b').removeClass('circle_w');
-      var latest_move = this.model.moves.last();
       if(latest_move){
+
         var cell = this.model.get_cell(latest_move.get('x'), latest_move.get('y'));
-        var overlay = cell.view.$el.find('.jgo_m');
+        var cell_view = this.get_cell_view(latest_move.get('x'), latest_move.get('y'));
+
+        var overlay = cell_view.$el.find('.jgo_m');
         if(cell.get('holds') == "white")
           $(overlay).addClass("circle_b");
         else
@@ -78,9 +94,6 @@
 
       var board_view = this;
       _.each(this.cell_views, function(cell_view) {
-        // make sure we keep reverse references across 'board-update' events
-        // the 'cells' attr of the Board isntance is being reset
-        cell_view.model.view = cell_view;
         $(".board", board_view.$el).append(cell_view.render());
       });
       return this.$el;

--- a/public/js/views/BoardView.js
+++ b/public/js/views/BoardView.js
@@ -9,12 +9,17 @@
     initialize: function(options) {
       options = options || {}
       this.player_color = options['player_color'];
-      this.cell_views = {};
-      var board_view = this;
-      _.each(_.flatten(this.model.cells), function(cell) {
-        new_cell_view = new weiqi.CellView({model: cell, board_view: board_view});
-        board_view.cell_views[board_view._cell_view_key(cell.get('x'), cell.get('y'))] = new_cell_view
-      });
+
+      this.cell_views = [];
+      for(var x = 0; x < this.model.get('width'); x++){
+        this.cell_views[x] = [];
+        for(var y = 0; y < this.model.get('width'); y++){
+          var cell = this.model.get_cell(x, y);
+          var new_cell_view = new weiqi.CellView({model: cell, board_view: this});
+          this.cell_views[x][y] = new_cell_view;
+        }
+      }
+
       this.template = _.template('\
         <div class="board board<%= width %>"> \
         </div> \
@@ -39,10 +44,9 @@
 
       this.render();
     },
-    _cell_view_key: function(x, y) { return x + '-' + y}, 
     get_cell_view: function(x, y) {
       if(x < this.model.get('width') && y < this.model.get('width')){
-        return this.cell_views[this._cell_view_key(x, y)];
+        return this.cell_views[x][y];
       }
       else {
         throw new Error("attempting to accessing outside of game board");
@@ -93,9 +97,12 @@
       }
 
       var board_view = this;
-      _.each(this.cell_views, function(cell_view) {
+      _(this.cell_views).chain()
+      .flatten()
+      .each(function(cell_view) {
         $(".board", board_view.$el).append(cell_view.render());
       });
+
       return this.$el;
     }
   });

--- a/spec/jasmine/models/CellSpec.js
+++ b/spec/jasmine/models/CellSpec.js
@@ -19,6 +19,16 @@ describe("Cell", function() {
     });
   });
 
+  describe("#cells", function() {
+    it("should fetch cells", function() {
+      expect(board.get_cell(2, 3)).toEqual(board.cells[2][3]);
+    });
+    it("should do boundary checking", function() {
+      expect(function() {
+        board.get_cell(20, 9)
+      }).toThrow();
+    });
+  });
   describe("#play", function() {
     describe("when the cell is empty", function() {
       beforeEach(function() {

--- a/spec/jasmine/views/BoardViewSpec.js
+++ b/spec/jasmine/views/BoardViewSpec.js
@@ -5,7 +5,7 @@ describe("BoardView", function() {
       var board = new weiqi.Board();
       var $el = $('<div>');
       var board_view = new weiqi.BoardView({model: board, el: $el});
-      expect(board_view.cell_views.length).toEqual(board.get('width') * board.get('width'));
+      expect(_.values(board_view.cell_views).length).toEqual(board.get('width') * board.get('width'));
     });
   });
 
@@ -41,14 +41,14 @@ describe("BoardView", function() {
     var board_view = new weiqi.BoardView({ model: board, el: $el });
 
     it("should render each of it's cells", function() {
-      spyOn(board_view.cell_views[0], 'render');
+      spyOn(board_view.get_cell_view(0, 0), 'render');
       //spot check
-      spyOn(board_view.cell_views[20], 'render');
+      spyOn(board_view.get_cell_view(1, 0), 'render');
 
       board_view.render();
 
-      expect(board_view.cell_views[0].render).toHaveBeenCalled();
-      expect(board_view.cell_views[20].render).toHaveBeenCalled();
+      expect(board_view.get_cell_view(0, 0).render).toHaveBeenCalled();
+      expect(board_view.get_cell_view(1, 0).render).toHaveBeenCalled();
     });
 
     describe("when it's the white player's board", function() {

--- a/spec/jasmine/views/BoardViewSpec.js
+++ b/spec/jasmine/views/BoardViewSpec.js
@@ -5,7 +5,7 @@ describe("BoardView", function() {
       var board = new weiqi.Board();
       var $el = $('<div>');
       var board_view = new weiqi.BoardView({model: board, el: $el});
-      expect(_.values(board_view.cell_views).length).toEqual(board.get('width') * board.get('width'));
+      expect(_.flatten(board_view.cell_views).length).toEqual(board.get('width') * board.get('width'));
     });
   });
 

--- a/spec/jasmine/views/CellViewSpec.js
+++ b/spec/jasmine/views/CellViewSpec.js
@@ -29,7 +29,7 @@ describe("CellView", function() {
 
   describe("#cell_views", function() {
     it("should fetch cells", function() {
-      expect(board_view.get_cell_view(2, 3)).toEqual(board_view.cell_views[2 + '-' +3]);
+      expect(board_view.get_cell_view(2, 3)).toEqual(board_view.cell_views[2][3]);
     });
     it("should do boundary checking", function() {
       expect(function() {

--- a/spec/jasmine/views/CellViewSpec.js
+++ b/spec/jasmine/views/CellViewSpec.js
@@ -27,29 +27,40 @@ describe("CellView", function() {
     });
   });
 
+  describe("#cell_views", function() {
+    it("should fetch cells", function() {
+      expect(board_view.get_cell_view(2, 3)).toEqual(board_view.cell_views[2 + '-' +3]);
+    });
+    it("should do boundary checking", function() {
+      expect(function() {
+        board_view.get_cell_view(20, 9)
+      }).toThrow();
+    });
+  });
+
   describe("marking last plays", function() {
     it("should mark a black circle if white played last", function() {
       board.play_black(0,0);
       board.play_white(0,1);
-      var cell_view = board.get_cell(0, 1).view;
+      var cell_view = board_view.get_cell_view(0, 1);
       expect(cell_view.$el.find('.jgo_m').hasClass('circle_b')).toBeTruthy()
     });
     it("should mark a white circle if black played last", function() {
       board.play_black(0,0);
       board.play_white(0,1);
       board.play_black(0,2);
-      var cell_view = board.get_cell(0, 2).view;
+      var cell_view = board_view.get_cell_view(0, 2);
       expect(cell_view.$el.find('.jgo_m').hasClass('circle_w')).toBeTruthy()
     });
     it("should should remove a mark after playing yet another piece", function() {
       board.play_black(0,0);
       board.play_white(0,1);
       // check the very first piece
-      var cell_view = board.get_cell(0, 0).view;
+      var cell_view = board_view.get_cell_view(0, 0);
       expect(cell_view.$el.find('.jgo_m').hasClass('circle_w')).toBeFalsy()
       board.play_black(0,2);
       // check the second to last 
-      cell_view = board.get_cell(0, 1).view;
+      cell_view = board_view.get_cell_view(0, 1);
       expect(cell_view.$el.find('.jgo_m').hasClass('circle_b')).toBeFalsy()
     });
   });


### PR DESCRIPTION
This is motivated by 8a79416bce3837b8529852081eda6987748b77f0 which is part of a WIP branch. The problem is that we are synchronizing the board state across the `update-board` event. When this event is fired the board reinitializes its state, rebuilding the cell arrays, but does not reinit the associated views.  This breaks all the reverse view relations on the cell_views that point to the cells.  

Anyways, reverse relations shouldn't be needed. The approach in this PR is to break the relation by indexing both the cells and the cell_views on their position in the board. This way we can join without worrying about stale relations.